### PR TITLE
Fixes for getNextRequest in UI

### DIFF
--- a/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
+++ b/packages/bruno-app/src/providers/ReduxStore/slices/collections/index.js
@@ -1306,29 +1306,29 @@ export const collectionsSlice = createSlice({
         }
 
         if (type === 'request-sent') {
-          const item = collection.runnerResult.items.find((i) => i.uid === request.uid);
+          const item = collection.runnerResult.items.find((i) => i.uid === request.uid && i.status === 'queued');
           item.status = 'running';
           item.requestSent = action.payload.requestSent;
         }
 
         if (type === 'response-received') {
-          const item = collection.runnerResult.items.find((i) => i.uid === request.uid);
+          const item = collection.runnerResult.items.find((i) => i.uid === request.uid && i.status === 'running');
           item.status = 'completed';
           item.responseReceived = action.payload.responseReceived;
         }
 
         if (type === 'test-results') {
-          const item = collection.runnerResult.items.find((i) => i.uid === request.uid);
+          const item = collection.runnerResult.items.find((i) => i.uid === request.uid && i.status === 'running');
           item.testResults = action.payload.testResults;
         }
 
         if (type === 'assertion-results') {
-          const item = collection.runnerResult.items.find((i) => i.uid === request.uid);
+          const item = collection.runnerResult.items.find((i) => i.uid === request.uid && i.status === 'running');
           item.assertionResults = action.payload.assertionResults;
         }
 
         if (type === 'error') {
-          const item = collection.runnerResult.items.find((i) => i.uid === request.uid);
+          const item = collection.runnerResult.items.find((i) => i.uid === request.uid && i.status === 'running');
           item.error = action.payload.error;
           item.responseReceived = action.payload.responseReceived;
           item.status = 'error';

--- a/packages/bruno-cli/src/commands/run.js
+++ b/packages/bruno-cli/src/commands/run.js
@@ -375,7 +375,7 @@ const handler = async function (argv) {
       const nextRequestName = result?.nextRequestName;
       if (nextRequestName) {
         const nextRequestIdx = bruJsons.findIndex((iter) => iter.bruJson.name === nextRequestName);
-        if (nextRequestIdx > 0) {
+        if (nextRequestIdx >= 0) {
           currentRequestIndex = nextRequestIdx;
         } else {
           console.error("Could not find request with name '" + nextRequestName + "'");

--- a/packages/bruno-electron/src/ipc/network/index.js
+++ b/packages/bruno-electron/src/ipc/network/index.js
@@ -976,7 +976,7 @@ const registerNetworkIpc = (mainWindow) => {
           }
           if (nextRequestName) {
             const nextRequestIdx = folderRequests.findIndex((request) => request.name === nextRequestName);
-            if (nextRequestIdx > 0) {
+            if (nextRequestIdx >= 0) {
               currentRequestIndex = nextRequestIdx;
             } else {
               console.error("Could not find request with name '" + nextRequestName + "'");


### PR DESCRIPTION
Discovered a couple of issues while trying out getNextRequest within the bruno UI. 

1. Runner behavior gets a bit wonky because multiple requests share the same uid. Fixed by checking status as well when looking up the actual request in the item list
2. Trying to go to first request in collection failed because its index is 0
![Screenshot 2023-10-20 at 12 24 27 PM](https://github.com/mj-h/bruno/assets/3820523/20989099-76bc-43a6-8930-a9c89362ed49)
